### PR TITLE
update version to 10.42

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pcre2" %}
-{% set version = "10.37" %}
+{% set version = "10.42" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/PhilipHazel/{{ name }}/releases/download/{{ name }}-{{ version }}/{{ name }}-{{ version }}.tar.bz2
-  sha256: 4d95a96e8b80529893b4562be12648d798b957b1ba1aae39606bbc2ab956d270
+  sha256: 8d36cd8cb6ea2a4c2bb358ff6411b0c788633a2a45dabbf1aeb4b701d1b5e840
 
 build:
   number: 1


### PR DESCRIPTION
I noticed there are many changes in the conda-forge recipe, including making this a multi-output recipe that creates several conda packages. However this is the simple change to update only the version # and hash. Dependencies etc. need to be checked.